### PR TITLE
fix issue with stack trace line missing file name and line number

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,9 +72,9 @@ This will create a Json like the one below (threads cut for brevity).
         "waited-time": -1,
         "state": "WAITING",
         "stack-trace": [
-          "sun.management.ThreadImpl(Native method)",
-          "sun.management.ThreadImpl(ThreadImpl.java:197)",
-          "org.dmonix.jmx.JMXJsonBuilder(JMXJsonBuilder.java:180)"
+          "jdk.internal.misc.Unsafe.park(Native method)",
+          "java.util.concurrent.locks.LockSupport.park(LockSupport.java:194)",
+          "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(AbstractQueuedSynchronizer.java:2081)"
         ]
       },
       {
@@ -86,9 +86,9 @@ This will create a Json like the one below (threads cut for brevity).
         "waited-time": -1,
         "state": "RUNNABLE",
         "stack-trace": [
-          "java.lang.ref.Reference(Native method)",
-          "java.lang.ref.Reference(Reference.java:241)",
-          "java.lang.ref.Reference$ReferenceHandler(Reference.java:213)"
+          "java.lang.ref.Reference.waitForReferencePendingList(Native method)",
+          "java.lang.ref.Reference.processPendingReferences(Reference.java:241)",
+          "java.lang.ref.Reference$ReferenceHandler.run(Reference.java:213)"
         ]
       },
      ...

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 organization  := "org.dmonix"
 name := "jmx-runtime-json"
-version := "1.1.0"
+version := "1.1.1"
 
 javacOptions ++= Seq("-source", "1.8", "-target", "1.8")
 javacOptions in (Compile, doc) := Seq("-source", "1.8")

--- a/src/main/java/org/dmonix/jmx/JMXJsonBuilder.java
+++ b/src/main/java/org/dmonix/jmx/JMXJsonBuilder.java
@@ -187,12 +187,7 @@ public class JMXJsonBuilder {
 
       JsonArray stackArray = Json.array();
       for (StackTraceElement ste : ti.getStackTrace()) {
-        String line =
-            ste.isNativeMethod()
-                ? String.format("%s(Native method)", ste.getClassName())
-                : String.format(
-                    "%s(%s:%d)", ste.getClassName(), ste.getFileName(), ste.getLineNumber());
-        stackArray.add(line);
+        stackArray.add(asString(ste));
       }
 
       JsonObject to = Json.object();
@@ -273,6 +268,20 @@ public class JMXJsonBuilder {
 
     builderJson.add("class-loading", jo);
     return this;
+  }
+
+  static String asString(StackTraceElement ste) {
+    String fileName = ste.getFileName();
+    int lineNumber = ste.getLineNumber();
+    if (ste.isNativeMethod()) {
+      return String.format("%s.%s(Native method)", ste.getClassName(), ste.getMethodName());
+    } else if (fileName != null && lineNumber >= 0) { // we have both file name and line number
+      return String.format(
+          "%s.%s(%s:%d)", ste.getClassName(), ste.getMethodName(), fileName, lineNumber);
+    } else if (fileName != null) { // we only have file name
+      return String.format("%s.%s(%s)", ste.getClassName(), ste.getMethodName(), fileName);
+    }
+    return String.format("%s.%s(Unknown source)", ste.getClassName(), ste.getMethodName());
   }
 
   /**

--- a/src/test/scala/org/dmonix/jmx/JMXJsonBuilderSpec.scala
+++ b/src/test/scala/org/dmonix/jmx/JMXJsonBuilderSpec.scala
@@ -163,6 +163,25 @@ class JMXJsonBuilderSpec extends Specification {
     }
   }
 
+  "StackTraceElement asString" >> {
+    val declaringClass = "org.dmonix.FooClass"
+    val methodName = "execute"
+    val fileName = "JMXBuilderSpec.scala"
+    val lineNumber = 69
+    "with class, file and line number shall return full line" >> {
+      JMXJsonBuilder.asString(new StackTraceElement(declaringClass, methodName, fileName, lineNumber)) === s"$declaringClass.$methodName($fileName:$lineNumber)"
+    }
+    "with class, file and no line number shall return string without line number" >> {
+      JMXJsonBuilder.asString(new StackTraceElement(declaringClass, methodName, fileName, -1)) === s"$declaringClass.$methodName($fileName)"
+    }
+    "with class, no file and no line number shall return line with class name" >> {
+      JMXJsonBuilder.asString(new StackTraceElement(declaringClass, methodName, null, -1)) === s"$declaringClass.$methodName(Unknown source)"
+    }
+    "with native method shall return line with class name" >> {
+      //apparently line.nr -2 counts as native method...hmmm
+      JMXJsonBuilder.asString(new StackTraceElement(declaringClass, methodName, fileName, -2)) === s"$declaringClass.$methodName(Native method)"
+    }
+  }
 
   private def assertRuntimeContents(json: JsonObject): MatchResult[_] = {
     val obj = json.getObject("runtime")


### PR DESCRIPTION
Added method name to the stack as well.
So the pattern is _{class}.{method}(file:line)_
If file nor line can be determined _"Unknown source"_ is printed.

issue: #3